### PR TITLE
Fix outdated comment in report upsert

### DIFF
--- a/app.py
+++ b/app.py
@@ -345,7 +345,7 @@ def upsert_report_by_date(date_str):
 
         data = request.get_json()
         
-        # Convert date string to date object
+        # date_str parsed earlier; parse again to ensure a date object
         date_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
 
         conn = get_connection()


### PR DESCRIPTION
## Summary
- clarify redundant date parsing comment in `upsert_report_by_date`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9deb783c8329bce356ff3469a465